### PR TITLE
Add first_seen and rows_sent to longest running query dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,6 @@
 
 * First tagged version.
 
-## v1.0.2 (2021-12-15)
+## v1.1.4 (2021-12-15)
 
 * Add first_seen and rows_sent to longest running query dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@
 ## v1.0.1 (2017-05-23)
 
 * First tagged version.
+
+## v1.0.2 (2021-12-15)
+
+* Add first_seen and rows_sent to longest running query dashboard


### PR DESCRIPTION
Adding first_seen & rows_sent columns to the exporter for visibility on our grafana dashboard.

This is to easily distinguish false data based on total_time information on the proxysql_queries_longest_running_total graph